### PR TITLE
Change systemctl status responce

### DIFF
--- a/docs/0022_ntp.md
+++ b/docs/0022_ntp.md
@@ -61,18 +61,18 @@ systemd-timesyncd.service active: yes
 $  systemctl status systemd-timesyncd
 ● systemd-timesyncd.service - Network Time Synchronization
    Loaded: loaded (/lib/systemd/system/systemd-timesyncd.service; enabled; vendor preset: enabled)
-   Active: inactive (dead) since Wed 2020-03-11 04:23:56 UTC; 40min ago
+   Active: active (running) since Thu 2020-03-12 12:21:25 JST; 9min ago
      Docs: man:systemd-timesyncd.service(8)
- Main PID: 26825 (code=exited, status=0/SUCCESS)
-   Status: "Idle."
+ Main PID: 3105 (systemd-timesyn)
+   Status: "Synchronized to time server 91.189.89.199:123 (ntp.ubuntu.com)."
+    Tasks: 2 (limit: 1152)
+   CGroup: /system.slice/systemd-timesyncd.service
+           └─3105 /lib/systemd/systemd-timesyncd
 
-Mar 11 02:26:31 ip-172-16-1-211 systemd-timesyncd[26825]: Network configuration changed, trying to es
-Mar 11 02:26:31 ip-172-16-1-211 systemd-timesyncd[26825]: Synchronized to time server 91.189.94.4:123
-Mar 11 02:56:30 ip-172-16-1-211 systemd-timesyncd[26825]: Network configuration changed, trying to es
-Mar 11 02:56:31 ip-172-16-1-211 systemd-timesyncd[26825]: Synchronized to time server 91.189.94.4:123
-Mar 11 03:26:30 ip-172-16-1-211 systemd-timesyncd[26825]: Network configuration changed, trying to es
-Mar 11 03:26:30 ip-172-16-1-211 systemd-timesyncd[26825]: Synchronized to time server 91.189.94.4:123
-Mar 11 03:56:30 ip-172-16-1-211 systemd-timesyncd[26825]: Network configuration changed, trying to es
+Mar 12 12:21:25 ip-172-16-1-20 systemd[1]: Stopped Network Time Synchronization.
+Mar 12 12:21:25 ip-172-16-1-20 systemd[1]: Starting Network Time Synchronization...
+Mar 12 12:21:25 ip-172-16-1-20 systemd[1]: Started Network Time Synchronization.
+Mar 12 12:21:25 ip-172-16-1-20 systemd-timesyncd[3105]: Synchronized to time server 91.189.89.199:123 (ntp.ubuntu.com)
 
 ```
 


### PR DESCRIPTION
```
systemctl status systemd-timesyncd
```
のResponseが`Active: inactive (dead)`だったので自分のResponseに変更しました